### PR TITLE
fix(REA-194): resolves path-to-regexp vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cordova",
-  "version": "12.2.0",
+  "version": "12.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cordova",
-      "version": "12.2.0",
+      "version": "12.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "configstore": "^5.0.1",
@@ -3630,9 +3630,9 @@
       "integrity": "sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw=="
     },
     "node_modules/express": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
-      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
@@ -3654,7 +3654,7 @@
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.10",
+        "path-to-regexp": "0.1.12",
         "proxy-addr": "~2.0.7",
         "qs": "6.13.0",
         "range-parser": "~1.2.1",
@@ -3669,6 +3669,10 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/express/node_modules/safe-buffer": {
@@ -6640,9 +6644,10 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w=="
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "license": "MIT"
     },
     "node_modules/path-type": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova",
-  "version": "12.2.0",
+  "version": "12.2.1",
   "description": "Cordova command line interface tool",
   "main": "cordova",
   "engines": {


### PR DESCRIPTION
What's wrong?

You have open high severity vulnerabilities.

Github Vulnerability

[npm-path-to-regexp < 0.1.12/CVE-2024-52798 (cordova-cli)](https://github.com/biblio-tech/cordova-cli/security/dependabot/12)

How to fix?

Visit the [Vulnerabilities page](https://app.eu.vanta.com/vulnerabilities/findings-by-vulnerability?source=github&severity=HIGH) to learn more about the unresolved vulnerabilities.

Remediate or deactivate monitoring for each unresolved vulnerability.

[Optional] If the vulnerability was resolved outside of the SLA you’ve defined, explain the reason to your auditor on the [SLA violations page](https://app.eu.vanta.com/vulnerabilities/history?tab=sla-misses).

This issue was automatically created from Vanta. [View test in Vanta](https://app.eu.vanta.com/tests/packages-checked-for-vulnerabilities-v2-records-closed-github-dependabot-high)